### PR TITLE
Remove coveralls step in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,9 +72,3 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: lcov.info
-
-      - name: Coveralls
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: lcov.info


### PR DESCRIPTION
This PR removes the coveralls step in the CI because codecov is already used.