### PR TITLE
Feature/docs cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![numericaltypes-header](docs/src/assets/header.png)][docs-dev-url]
 
-A collection of type aliases restricting to numerical for multiple dispatch.
+A collection of simple type aliases restricting to numerical vectors or matrices for multiple dispatch.
 
 Please read the [documentation][docs-dev-url] for detailed usage and tutorials.
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ But today is not that day.
 
 The Julia unit testing coverage methods don't seem to concern themselves with constant aliases of types, which is the only thing that this package contains.
 Despite the fact that these types are tested with various assertions, these sadly don't register as covered lines.
+Full coverage reporting is planned for this package in the future, but today is not that day.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Furthermore, the package exports some convenience variables:
 - [`NTA_VERSION`][9]: the version of `NumericalTypeAliases.jl` that is installed on the system.
 - [`NTA_ABSTRACT_TYPES`][10]: a list of the abstract types in the package.
 - [`NTA_CONCRETE_TYPES`][11]: a list of the concrete types in the package.
-- ['NTA_TYPES`][12]: a combined list of all abstract and concrete types in the package.
+- [`NTA_TYPES`][12]: a combined list of all abstract and concrete types in the package.
 
 [1]: https://AP6YC.github.io/NumericalTypeAliases.jl/dev/man/full-index/#NumericalTypeAliases.RealArray
 [2]: https://AP6YC.github.io/NumericalTypeAliases.jl/dev/man/full-index/#NumericalTypeAliases.RealVector

--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -4,7 +4,7 @@ The use the `NumericalTypeAliases.jl` package, you should know:
 
 - [How to install the package](@ref installation)
 - [Usage basics](@ref usage)
-- [Types and constants](@ref types-constants)
+- [Aliases](@ref types-constants)
 
 ## [Installation](@id installation)
 
@@ -82,7 +82,7 @@ MyStruct(3.14)
 This is just like in base Julia where `Integer` is the abstract type, and `Int` is the concrete type.
 This `Float` type is provided for semantic convenience, though beware that it has been the [subject of great debate](https://discourse.julialang.org/t/float-type-like-int-type/1164).
 
-## [Types and Constants](@id types-constants)
+## [Aliases](@id types-constants)
 
 The aliases exported in this package are:
 

--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -88,7 +88,7 @@ The aliases exported in this package are:
 
 ```@meta
 CurrentModule=NumericalTypeAliases
-````
+```
 
 - Real-valued arrays:
   - [`RealArray`](@ref): an arbitrary size array of floats.

--- a/src/aliases.jl
+++ b/src/aliases.jl
@@ -76,14 +76,14 @@ const Float = typeof(0.0)
 # --------------------------------------------------------------------------- #
 
 """
-A list of NumericalTypeAliases concrete types.
+A list of all `NumericalTypeAliases` concrete types.
 """
 const NTA_CONCRETE_TYPES = [
     Float,
 ]
 
 """
-A list of `NumericalTypeAliases`` abstract types.
+A list of all `NumericalTypeAliases` abstract types.
 """
 const NTA_ABSTRACT_TYPES = [
     RealArray,
@@ -96,7 +96,7 @@ const NTA_ABSTRACT_TYPES = [
 ]
 
 """
-A combined list of abstract and concrete types exported in the `NumericalTypeAliases` package.
+A combined list of all abstract and concrete types exported in the `NumericalTypeAliases` package.
 """
 const NTA_TYPES = [
     NTA_CONCRETE_TYPES;


### PR DESCRIPTION
This feature folds in simple changes to the documentation, such as fixing typos and expanding descriptions where relevant.